### PR TITLE
Fix compiler warning: defined but not used

### DIFF
--- a/Sources/yapi/ytcp.c
+++ b/Sources/yapi/ytcp.c
@@ -112,7 +112,7 @@ int yNetSetErrEx(u32 line,unsigned err,char *errmsg)
 #endif
     return YAPI_IO_ERROR;
 }
-#if 1
+#ifdef Y_UPNP_DETECT
 #define yNetLogErr()  yNetLogErrEx(__LINE__,SOCK_ERR)
 static int yNetLogErrEx(u32 line,unsigned err)
 {


### PR DESCRIPTION
../Sources/yapi/ytcp.c:118: warning: ‘yNetLogErrEx’ defined but not used

This is because yNetLogErr() (or yNetLogErrEx()) is used only in code
compiled when Y_UPNP_DETECT is defined.

Y_UPNP_DETECT is _not_ defined by default so the compiler generates the
warning
