### PR TITLE
Fix bug building libyapi.dylib on OS X

### DIFF
--- a/Binaries/GNUmakefile
+++ b/Binaries/GNUmakefile
@@ -400,7 +400,7 @@ $(DIR_OSX)libyocto.dylib: $(DIR_OSX) $(ALL_OBJS_DYN_OSX) $(ALL_H)
 	@echo linking $@
 	@$(CPP_OSX)  -m64 -dynamiclib -Wl,-reexport_framework,IOKit,-reexport_framework,CoreFoundation,-headerpad_max_install_names,-undefined,dynamic_lookup,-compatibility_version,1.0,-current_version,1.0,-install_name,/usr/local/lib/libyocto.dylib -o $@ $(ALL_OBJS_DYN_OSX) 
 
-$(DIR_OSX)libyapi.dylib: $(DIR_OSX) $(YAPI_OBJS_DYN_OSX) $(ALL_H)
+$(YAPI_DIR_OSX)libyapi.dylib: $(DIR_OSX) $(YAPI_OBJS_DYN_OSX) $(ALL_H)
 	@echo linking $@
 	@$(CC_OSX} -m64 -dynamiclib -Wl,-reexport_framework,IOKit,-reexport_framework,CoreFoundation,-headerpad_max_install_names,-undefined,dynamic_lookup,-compatibility_version,1.0,-current_version,1.0,-install_name,/usr/local/lib/libyapi.dylib -o $@ $(YAPI_OBJS_DYN_OSX) 
 


### PR DESCRIPTION
To build from scratch on Mac OS X I manually removed all .o, .a and .dylib files then ran 'make'.  The build stopped at the final linking step with:
  make: **\* No rule to make target `osx/yapi/libyapi.dylib', needed by`osx'.  Stop.

My proposed change fixes this bug and allow the make to complete
