### PR TITLE
Remove redundant delarations

### DIFF
--- a/Sources/yocto_api.h
+++ b/Sources/yocto_api.h
@@ -316,12 +316,6 @@ typedef struct{
     };
 }yapiDataEvent;
 
-
-// internal helper function
-s64 yatoi(const char *c);
-int _ystrpos(const string& haystack, const string& needle);
-vector<string> _strsplit(const string& str, char delimiter);
-
 typedef enum {
     STRING,
     NUMBER,


### PR DESCRIPTION
Fixes compiler warnings:
yoctolib_cpp/Sources/yocto_api.h:321:5: warning: redundant redeclaration of ‘s64 yatoi(const char*)’ in same scope [-Wredundant-decls]
 s64 yatoi(const char *c);
     ^~~~~
yoctolib_cpp/Sources/yocto_api.h:87:5: note: previous declaration of ‘s64 yatoi(const char*)’
 s64 yatoi(const char *c);
     ^~~~~

yoctolib_cpp/Sources/yocto_api.h:322:5: warning: redundant redeclaration of ‘int _ystrpos(const string&, const string&)’ in same scope -Wredundant-decls]
 int _ystrpos(const string& haystack, const string& needle);
     ^~~~~~~~
yoctolib_cpp/Sources/yocto_api.h:88:5: note: previous declaration of ‘int _ystrpos(const string&, const string&)’
 int _ystrpos(const string& haystack, const string& needle);
     ^~~~~~~~

yoctolib_cpp/Sources/yocto_api.h:323:16: warning: redundant redeclaration of ‘std::vector<std::__cxx11::basic_string<char> > _strsplit(const string&, char)’ in same scope [-Wredundant-decls]
 vector<string> _strsplit(const string& str, char delimiter);
                ^~~~~~~~~
yoctolib_cpp/Sources/yocto_api.h:89:16: note: previous declaration of ‘std::vector<std::__cxx11::basic_string<char> > _strsplit(const string&, char)’
 vector<string> _strsplit(const string& str, char delimiter);
                ^~~~~~~~~